### PR TITLE
potential null reference fix

### DIFF
--- a/lib/post-css-helper.js
+++ b/lib/post-css-helper.js
@@ -31,6 +31,11 @@ PostCssHelper.getRuleSourceLocation = function(rule) {
   if (typeof filePath === 'string' && !path.isAbsolute(filePath)) {
     filePath = path.resolve(path.dirname(rule.source.input.file), filePath);
   }
+
+  if (filePath === null) {
+    filePath = path.resolve(rule.source.input.file);
+  }
+
   return {
     filePath: filePath,
     line: line,


### PR DESCRIPTION
hey Jan!

Sometimes this lookup function returns null - still I'm not sure why. My quick-fix is to return `rule.source.input.file` in case this happens but I'm honestly not sure if this is a real fix. Maybe you can have a look.

cheers
